### PR TITLE
Correct external link

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -13,7 +13,7 @@
             {%- endif -%}
             </li>
             {%- if site.externallink -%}
-            <li><a class="u-email" href="http://{{ site.externallink }}">{{ site.externallink }}</a></li>
+            <li><a class="u-email" href="{{ site.externallink }}">{{ site.externallink }}</a></li>
             {%- endif -%}
         </ul>
       </div>


### PR DESCRIPTION
Hi! Just a small fix I noticed:

URL prefix already included in `site.externallink`; meaning the link did not work